### PR TITLE
Persist rating for buttons

### DIFF
--- a/src/classes/ButtonHandler.ts
+++ b/src/classes/ButtonHandler.ts
@@ -29,7 +29,7 @@ export default class ButtonHandler {
     const customId = ctx.data.custom_id as ButtonIdsWithState;
     const [id, rating] = customId.split(':') as [QuestionTypeButtonIds, Rating | undefined];
 
-    if (!this.buttonIds.includes(id as QuestionTypeButtonIds))
+    if (!this.buttonIds.includes(id))
       return this.client.console.error(
         `Button ${customId} was pressed with no corresponding question type.`
       );

--- a/src/classes/Server.ts
+++ b/src/classes/Server.ts
@@ -10,7 +10,7 @@ import { fastify, FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import fastifyRateLimit, { RateLimitOptions } from '@fastify/rate-limit';
 import metricsPlugin from 'fastify-metrics';
 import { QuestionType, Rating } from '.prisma/client';
-import { PlatformAlgorithm, verify } from 'discord-verify/node';
+import { verify } from 'discord-verify/node';
 import crypto from 'node:crypto';
 import * as Sentry from '@sentry/node';
 import { register } from 'prom-client';
@@ -96,8 +96,7 @@ export default class Server {
       signature,
       timestamp,
       this.client.publicKey,
-      crypto.webcrypto.subtle,
-      PlatformAlgorithm.OldNode
+      crypto.webcrypto.subtle
     );
 
     if (!isValidRequest) return res.code(401).send('Invalid signature');

--- a/src/commands/dare.ts
+++ b/src/commands/dare.ts
@@ -53,7 +53,7 @@ const dare: Command = {
       ],
       components: serverSettings?.disableButtons
         ? []
-        : ctx.client.server.buttonHandler.components('TOD'),
+        : ctx.client.server.buttonHandler.components('TOD', rating),
     });
   },
 };

--- a/src/commands/nhie.ts
+++ b/src/commands/nhie.ts
@@ -53,7 +53,7 @@ const nhie: Command = {
       ],
       components: serverSettings?.disableButtons
         ? []
-        : ctx.client.server.buttonHandler.components('NHIE'),
+        : ctx.client.server.buttonHandler.components('NHIE', rating),
     });
   },
 };

--- a/src/commands/paranoia.ts
+++ b/src/commands/paranoia.ts
@@ -61,7 +61,7 @@ const paranoia: Command = {
         ],
         components: serverSettings?.disableButtons
           ? []
-          : ctx.client.server.buttonHandler.components('PARANOIA'),
+          : ctx.client.server.buttonHandler.components('PARANOIA', rating),
       });
     }
 

--- a/src/commands/random.ts
+++ b/src/commands/random.ts
@@ -53,7 +53,7 @@ const tod: Command = {
       ],
       components: serverSettings?.disableButtons
         ? []
-        : ctx.client.server.buttonHandler.components('RANDOM'),
+        : ctx.client.server.buttonHandler.components('RANDOM', rating),
     });
   },
 };

--- a/src/commands/tod.ts
+++ b/src/commands/tod.ts
@@ -54,7 +54,7 @@ const tod: Command = {
       ],
       components: serverSettings?.disableButtons
         ? []
-        : ctx.client.server.buttonHandler.components('TOD'),
+        : ctx.client.server.buttonHandler.components('TOD', rating),
     });
   },
 };

--- a/src/commands/truth.ts
+++ b/src/commands/truth.ts
@@ -53,7 +53,7 @@ const truth: Command = {
       ],
       components: serverSettings?.disableButtons
         ? []
-        : ctx.client.server.buttonHandler.components('TOD'),
+        : ctx.client.server.buttonHandler.components('TOD', rating),
     });
   },
 };

--- a/src/commands/wyr.ts
+++ b/src/commands/wyr.ts
@@ -53,7 +53,7 @@ const wyr: Command = {
       ],
       components: serverSettings?.disableButtons
         ? []
-        : ctx.client.server.buttonHandler.components('WYR'),
+        : ctx.client.server.buttonHandler.components('WYR', rating),
     });
   },
 };


### PR DESCRIPTION
When a command is used with a rating explicitly chosen (like `/truth rating:PG`), if a button on the response message is pressed, it chooses a random rating.

This PR makes it so buttons from those messages (and subsequent messages from such buttons) will continue using the selected rating. If a rating is not explicitly specified, a random one will be chosen as before.