### PR TITLE
fix: don't mutate cache when disabling rating

### DIFF
--- a/src/classes/Client.ts
+++ b/src/classes/Client.ts
@@ -216,7 +216,7 @@ export default class Client {
   }
 
   async getQuestion(ctx: Context, type?: QuestionType, rating?: Rating | 'NONE') {
-    const disabledRatings = (await ctx.channelSettings).disabledRatings;
+    const disabledRatings = [...(await ctx.channelSettings).disabledRatings];
     if (this.enableR) {
       // R bot
       if (rating === 'NONE') rating = undefined;


### PR DESCRIPTION
The current way of disabling R-rated questions for the SFW bot mutates the cache, thereby disabling it for the 18+ bot until the cache is refreshed. Cloning the cached array prevents this from happening.

Example of this happening:
<img width="251" alt="CleanShot 2022-10-14 at 12 29 30@2x" src="https://user-images.githubusercontent.com/36977340/195895818-4b385c48-ddfd-4a7a-9502-b0b0201f84b3.png">