### PR TITLE
Scheduled question autothreading

### DIFF
--- a/src/classes/Client.ts
+++ b/src/classes/Client.ts
@@ -275,11 +275,7 @@ export default class Client {
               .toString()
           : null;
       if (typeof commandFile.contexts === 'undefined')
-        commandFile.contexts = [
-          ApplicationCommandContext.Guild,
-          ApplicationCommandContext.BotDM,
-          // ApplicationCommandContext.PrivateChannel,
-        ]; // Enables for guilds and bot-user DMs by default
+        commandFile.contexts = [ApplicationCommandContext.Guild, ApplicationCommandContext.BotDM]; // Enables for guilds and bot-user DMs by default
       if (commandFile.options)
         this.removeRatings(commandFile.options as APIApplicationCommandOption[]);
       this.commands.push(commandFile);

--- a/src/classes/Command.ts
+++ b/src/classes/Command.ts
@@ -7,7 +7,7 @@ import type Context from './Context';
 export enum ApplicationCommandContext {
   Guild = 0, // Allow command in guilds
   BotDM = 1, // Allow command in user-bot DMs
-  PrivateChannel = 2, // Allow command in user-user or group DMs
+  // PrivateChannel = 2, // Allow command in user-user or group DMs (not currently supported)
 }
 
 export default interface Command {

--- a/src/classes/Functions.ts
+++ b/src/classes/Functions.ts
@@ -12,6 +12,7 @@ import {
   ButtonStyle,
   APIEmbed,
   RESTPatchAPIInteractionFollowupJSONBody,
+  RESTPostAPIChannelThreadsJSONBody,
 } from 'discord-api-types/v9';
 import superagent from 'superagent';
 
@@ -199,6 +200,23 @@ export async function editMessage(
       `${
         process.env.DISCORD_API_URL || 'https://discord.com'
       }/api/channels/${channelId}/messages/${messageId}`
+    )
+    .send(data)
+    .set('Authorization', `Bot ${token}`)
+    .then(res => res.body);
+}
+
+export async function startThreadFromMessage(
+  data: RESTPostAPIChannelThreadsJSONBody,
+  channelId: string,
+  messageId: string,
+  token: string
+) {
+  return await superagent
+    .post(
+      `${
+        process.env.DISCORD_API_URL || 'https://discord.com'
+      }/api/channels/${channelId}/messages/${messageId}/threads`
     )
     .send(data)
     .set('Authorization', `Bot ${token}`)

--- a/src/classes/ScheduledQuestionHandler.ts
+++ b/src/classes/ScheduledQuestionHandler.ts
@@ -35,6 +35,14 @@ export default class ScheduledQuestionHandler {
           scheduledQuestionChannel.id,
           this.client.token
         )
+        .then(m => {
+          this.client.functions.startThreadFromMessage(
+            { name: 'Thread', auto_archive_duration: 1440 },
+            scheduledQuestionChannel.id,
+            m?.id || 'stop yelling at me',
+            this.client.token
+          );
+        })
         .catch(err => {
           if (err.response.body.code === 10003)
             this.client.database.deleteScheduledQuestionChannel(scheduledQuestionChannel.id);

--- a/src/classes/ScheduledQuestionHandler.ts
+++ b/src/classes/ScheduledQuestionHandler.ts
@@ -43,7 +43,7 @@ export default class ScheduledQuestionHandler {
             );
         });
 
-      if (sentMessage != null) {
+      if (scheduledQuestionChannel.autoThread && sentMessage != null) {
         const threadTitle =
           questionMessageData.embeds?.[0].title ??
           questionMessageData.embeds?.[0].description ??

--- a/src/classes/ScheduledQuestionHandler.ts
+++ b/src/classes/ScheduledQuestionHandler.ts
@@ -50,7 +50,7 @@ export default class ScheduledQuestionHandler {
           'Thread';
         this.client.functions
           .startThreadFromMessage(
-            { name: threadTitle },
+            { name: threadTitle, auto_archive_duration: 1440 },
             scheduledQuestionChannel.id,
             sentMessage.id,
             this.client.token

--- a/src/commands/dare.ts
+++ b/src/commands/dare.ts
@@ -25,11 +25,7 @@ const dare: Command = {
   category: 'question',
   options,
   perms: [],
-  contexts: [
-    ApplicationCommandContext.Guild,
-    ApplicationCommandContext.BotDM,
-    ApplicationCommandContext.PrivateChannel,
-  ],
+  contexts: [ApplicationCommandContext.Guild, ApplicationCommandContext.BotDM],
   run: async (ctx: Context): Promise<void> => {
     const serverSettings = ctx.guildId
       ? await ctx.client.database.fetchGuildSettings(ctx.guildId)

--- a/src/commands/nhie.ts
+++ b/src/commands/nhie.ts
@@ -25,11 +25,7 @@ const nhie: Command = {
   category: 'question',
   options: options,
   perms: [],
-  contexts: [
-    ApplicationCommandContext.Guild,
-    ApplicationCommandContext.BotDM,
-    ApplicationCommandContext.PrivateChannel,
-  ],
+  contexts: [ApplicationCommandContext.Guild, ApplicationCommandContext.BotDM],
   run: async (ctx: Context): Promise<void> => {
     const serverSettings = ctx.guildId
       ? await ctx.client.database.fetchGuildSettings(ctx.guildId)

--- a/src/commands/paranoia.ts
+++ b/src/commands/paranoia.ts
@@ -32,11 +32,7 @@ const paranoia: Command = {
   category: 'question',
   options,
   perms: [],
-  contexts: [
-    ApplicationCommandContext.Guild,
-    ApplicationCommandContext.BotDM,
-    ApplicationCommandContext.PrivateChannel,
-  ],
+  contexts: [ApplicationCommandContext.Guild, ApplicationCommandContext.BotDM],
   run: async (ctx: Context): Promise<void> => {
     const serverSettings = ctx.guildId
       ? await ctx.client.database.fetchGuildSettings(ctx.guildId)

--- a/src/commands/random.ts
+++ b/src/commands/random.ts
@@ -25,11 +25,7 @@ const tod: Command = {
   category: 'question',
   options,
   perms: [],
-  contexts: [
-    ApplicationCommandContext.Guild,
-    ApplicationCommandContext.BotDM,
-    ApplicationCommandContext.PrivateChannel,
-  ],
+  contexts: [ApplicationCommandContext.Guild, ApplicationCommandContext.BotDM],
   run: async (ctx: Context): Promise<void> => {
     const serverSettings = ctx.guildId
       ? await ctx.client.database.fetchGuildSettings(ctx.guildId)

--- a/src/commands/scheduled-question.ts
+++ b/src/commands/scheduled-question.ts
@@ -140,7 +140,7 @@ const scheduledQuestion: Command = {
             description: scheduledQuestionsForGuild
               .map(
                 sc =>
-                  `• **${ctx.client.functions.titleCase(sc.schedule)}:** <#${sc.id}> - ${
+                  `- **${ctx.client.functions.titleCase(sc.schedule)}:** <#${sc.id}> - ${
                     sc.type || ''
                   } ${sc.rating || ''} ${sc.role ? `Pings <@&${sc.role}>` : ''}`
               )

--- a/src/commands/scheduled-question.ts
+++ b/src/commands/scheduled-question.ts
@@ -51,6 +51,15 @@ const options = [
         name: 'role',
         description: 'The role to ping whenever a question is sent.',
       },
+      {
+        type: ApplicationCommandOptionType.String,
+        name: 'auto-thread',
+        description: 'Automatically create a thread under each question.',
+        choices: [
+          { name: 'Enabled', value: 'TRUE' },
+          { name: 'Disabled', value: 'FALSE' },
+        ],
+      },
     ],
   },
   {
@@ -100,6 +109,9 @@ const scheduledQuestion: Command = {
       let rating = ctx.getOption<Mutable<typeof options[0]['options'][2]>>('rating')?.value || null;
       const pingRole =
         ctx.getOption<Mutable<typeof options[0]['options'][3]>>('role')?.value || null;
+      const autoThreadEnabled =
+        ctx.getOption<Mutable<typeof options[0]['options'][3]>>('auto-thread')?.value === 'TRUE' ||
+        false;
 
       if (questionType === 'NONE') questionType = null;
       if (rating === 'NONE') rating = null;
@@ -112,6 +124,7 @@ const scheduledQuestion: Command = {
         type: questionType,
         rating,
         role: pingRole,
+        autoThread: autoThreadEnabled,
       });
 
       return ctx.reply(
@@ -142,7 +155,9 @@ const scheduledQuestion: Command = {
                 sc =>
                   `- **${ctx.client.functions.titleCase(sc.schedule)}:** <#${sc.id}> - ${
                     sc.type || ''
-                  } ${sc.rating || ''} ${sc.role ? `Pings <@&${sc.role}>` : ''}`
+                  } ${sc.rating || ''} ${sc.autoThread ? 'Auto-thread enabled' : ''} ${
+                    sc.role ? `Pings <@&${sc.role}>` : ''
+                  }`
               )
               .join('\n'),
             footer: {

--- a/src/commands/start-game.ts
+++ b/src/commands/start-game.ts
@@ -37,11 +37,7 @@ const game: Command = {
   category: 'question',
   options,
   perms: [],
-  contexts: [
-    ApplicationCommandContext.Guild,
-    ApplicationCommandContext.BotDM,
-    ApplicationCommandContext.PrivateChannel,
-  ],
+  contexts: [ApplicationCommandContext.Guild, ApplicationCommandContext.BotDM],
   run: async (ctx: Context): Promise<void> => {
     const rating = ctx.getOption<Mutable<typeof options[1]>>('rating')?.value;
     const specifiedQuestionType = ctx.getOption<Mutable<typeof options[0]>>('type')?.value;

--- a/src/commands/tod.ts
+++ b/src/commands/tod.ts
@@ -25,11 +25,7 @@ const tod: Command = {
   category: 'question',
   options,
   perms: [],
-  contexts: [
-    ApplicationCommandContext.Guild,
-    ApplicationCommandContext.BotDM,
-    ApplicationCommandContext.PrivateChannel,
-  ],
+  contexts: [ApplicationCommandContext.Guild, ApplicationCommandContext.BotDM],
   run: async (ctx: Context): Promise<void> => {
     const serverSettings = ctx.guildId
       ? await ctx.client.database.fetchGuildSettings(ctx.guildId)

--- a/src/commands/truth.ts
+++ b/src/commands/truth.ts
@@ -25,11 +25,7 @@ const truth: Command = {
   category: 'question',
   options,
   perms: [],
-  contexts: [
-    ApplicationCommandContext.Guild,
-    ApplicationCommandContext.BotDM,
-    ApplicationCommandContext.PrivateChannel,
-  ],
+  contexts: [ApplicationCommandContext.Guild, ApplicationCommandContext.BotDM],
   run: async (ctx: Context): Promise<void> => {
     const serverSettings = ctx.guildId
       ? await ctx.client.database.fetchGuildSettings(ctx.guildId)

--- a/src/commands/wyr.ts
+++ b/src/commands/wyr.ts
@@ -25,11 +25,7 @@ const wyr: Command = {
   category: 'question',
   options,
   perms: [],
-  contexts: [
-    ApplicationCommandContext.Guild,
-    ApplicationCommandContext.BotDM,
-    ApplicationCommandContext.PrivateChannel,
-  ],
+  contexts: [ApplicationCommandContext.Guild, ApplicationCommandContext.BotDM],
   run: async (ctx: Context): Promise<void> => {
     const serverSettings = ctx.guildId
       ? await ctx.client.database.fetchGuildSettings(ctx.guildId)

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -91,13 +91,14 @@ model CustomQuestion {
 }
 
 model ScheduledQuestionChannel {
-  id       String        @id @map("_id")
-  botId    String
-  guildId  String
-  schedule ScheduleType
-  role     String?
-  type     QuestionType?
-  rating   Rating?
+  id         String        @id @map("_id")
+  botId      String
+  guildId    String
+  schedule   ScheduleType
+  role       String?
+  type       QuestionType?
+  rating     Rating?
+  autoThread Boolean
 }
 
 model PremiumUser {


### PR DESCRIPTION
Adds the ability to enable scheduled question autothreading, which automatically creates a thread for every question sent. 

Adds a thread request function, which the code uses to create the threads.
A new database parameter for "autoThread" on ScheduledQuestionChannel was added, requiring migration of the current database.

![CleanShot 2024-01-04 at 15 11 09](https://github.com/tandpfun/truth-or-dare/assets/28990589/c3691dbc-b4aa-4cf4-b52f-0b62f3fba8a0)
